### PR TITLE
Fix for redis 5.x

### DIFF
--- a/katalyst-healthcheck.gemspec
+++ b/katalyst-healthcheck.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   spec.add_dependency "activesupport", ">= 3"
-  spec.add_dependency "redis", ">= 3", "< 5"
+  spec.add_dependency "redis", ">= 3"
   spec.add_dependency "redlock", ">= 1.2"
 end

--- a/lib/katalyst/healthcheck/store/redis.rb
+++ b/lib/katalyst/healthcheck/store/redis.rb
@@ -91,7 +91,7 @@ module Katalyst
         end
 
         def client
-          @client ||= ::Redis.new(options.to_h)
+          @client ||= ::Redis.new(url: options.url)
         end
 
         def lock_manager


### PR DESCRIPTION
cache_key is not a valid Redis option. Just pass in url